### PR TITLE
Fix improper_ctypes issue and re-enable warning 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplemad"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Benjamin Dykstra <bendykst@gmail.com>"]
 description = "An interface for libmad, the MPEG audio decoding library"
 repository = "https://github.com/bendykst/simple-mad.rs"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ let file = File::open(&path).unwrap();
 let decoder = Decoder::new(file);
 ```
 
-`Decoder` implements `Iterator` and yields `Result<Frame>`.
+`Decoder` implements `Iterator`, yielding `Result<Frame, MadError>`.
 
 ```Rust
 for item in decoder {
@@ -33,7 +33,7 @@ libmad samples are signed 32-bit integers. MP3 files often begin with metadata, 
 
 # Installation
 
-First, install libmad. Links to the source can be found below. It might be necessary to apply the patch found in [this guide](http://www.linuxfromscratch.org/blfs/view/svn/multimedia/libmad.html). Then add `simplemad = "0.2.2"` to the list of dependencies in your Cargo.toml.
+First, install libmad. Links to the source can be found below. It might be necessary to apply the patch found in [this guide](http://www.linuxfromscratch.org/blfs/view/svn/multimedia/libmad.html). Then add `simplemad = "0.2.3"` to the list of dependencies in your Cargo.toml.
 
 # Documentation
 


### PR DESCRIPTION
Previously, several ffi callback functions had signatures with improper types. These have been replaced with raw pointers which are cast to the required types in the callback functions.