### PR TITLE
Tweak simple-mad's Cargo.toml

### DIFF
--- a/simplemad/Cargo.toml
+++ b/simplemad/Cargo.toml
@@ -13,5 +13,4 @@ license = "MIT"
 name = "simplemad"
 
 [dependencies]
-libc = "0.1.6"
 simplemad_sys = { version = "0.1.0", path = "../simplemad_sys" }

--- a/simplemad/Cargo.toml
+++ b/simplemad/Cargo.toml
@@ -14,5 +14,4 @@ name = "simplemad"
 
 [dependencies]
 libc = "0.1.6"
-simplemad_sys = "0.1.0"
-
+simplemad_sys = { version = "0.1.0", path = "../simplemad_sys" }

--- a/simplemad/src/lib.rs
+++ b/simplemad/src/lib.rs
@@ -49,7 +49,7 @@ let frames: Vec<Frame> = partial_decoder.unwrap()
 #![crate_name = "simplemad"]
 
 extern crate simplemad_sys;
-extern crate libc;
+
 use std::io;
 use std::io::Read;
 use std::default::Default;


### PR DESCRIPTION
You can specify a path in your Cargo.toml in addition to the version. The path will be used when compiling locally and will be automatically ignored when publishing on crates.io.

The dependency towards `libc` is unused so I removed it.